### PR TITLE
Add hardcoded FOD FileName

### DIFF
--- a/windows/application-management/manage-windows-mixed-reality.md
+++ b/windows/application-management/manage-windows-mixed-reality.md
@@ -45,7 +45,7 @@ Organizations that use Windows Server Update Services (WSUS) must take action to
     Dism /Online /add-package /packagepath:(path)
     ```
     >[!NOTE]
-    >You must rename the FOD .CAB file to : **Microsoft-Windows-Holographic-Desktop-FOD-Package\~31bf3856ad364e35\~amd64\~~.cab**
+    >You must rename the FOD .CAB file to : **Microsoft-Windows-Holographic-Desktop-FOD-Package\~31bf3856ad364e35\~amd64\~\~.cab**
 
    c. In **Settings** > **Update & Security** > **Windows Update**, select **Check for updates**.
 

--- a/windows/application-management/manage-windows-mixed-reality.md
+++ b/windows/application-management/manage-windows-mixed-reality.md
@@ -44,6 +44,8 @@ Organizations that use Windows Server Update Services (WSUS) must take action to
     Add-Package
     Dism /Online /add-package /packagepath:(path)
     ```
+    >[!NOTE]
+    >You must rename the FOD .CAB file to : **Microsoft-Windows-Holographic-Desktop-FOD-Package\~31bf3856ad364e35\~amd64\~~.cab**
 
    c. In **Settings** > **Update & Security** > **Windows Update**, select **Check for updates**.
 


### PR DESCRIPTION
For offline scenarios, the name must be Microsoft-Windows-Holographic-Desktop-FOD-Package\~31bf3856ad364e35\~amd64\~\~.cab 
For 1903/1909, the file name is Microsoft-Windows-Holographic-Desktop-FOD-Package-31bf3856ad364e35-amd64.cab and MixedReality installation will fail. This is because the Filename is hardcoded in FOD Metadata and the file must be Microsoft-Windows-Holographic-Desktop-FOD-Package\~31bf3856ad364e35\~amd64\~\~.cab